### PR TITLE
Remove outdated natures to ensure that Eclipse does not attempt to lo…

### DIFF
--- a/plugins/org.eclipse.jem.beaninfo.vm.common/.project
+++ b/plugins/org.eclipse.jem.beaninfo.vm.common/.project
@@ -20,19 +20,9 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<buildCommand>
-			<name>com.ibm.rtp.tools.rose.builder</name>
-			<arguments>
-				<dictionary>
-					<key>rose</key>
-					<value></value>
-				</dictionary>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>com.ibm.rtp.tools.rose.toolnature</nature>
 	</natures>
 </projectDescription>

--- a/plugins/org.eclipse.jst.ejb.ui/.project
+++ b/plugins/org.eclipse.jst.ejb.ui/.project
@@ -24,6 +24,5 @@
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>com.ibm.etools.ctc.javaprojectnature</nature>
 	</natures>
 </projectDescription>

--- a/plugins/org.eclipse.jst.j2ee.jca.ui/.project
+++ b/plugins/org.eclipse.jst.j2ee.jca.ui/.project
@@ -24,6 +24,5 @@
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>com.ibm.etools.ctc.javaprojectnature</nature>
 	</natures>
 </projectDescription>

--- a/plugins/org.eclipse.jst.j2ee.navigator.ui/.project
+++ b/plugins/org.eclipse.jst.j2ee.navigator.ui/.project
@@ -24,6 +24,5 @@
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>com.ibm.etools.ctc.javaprojectnature</nature>
 	</natures>
 </projectDescription>

--- a/plugins/org.eclipse.jst.j2ee.ui/.project
+++ b/plugins/org.eclipse.jst.j2ee.ui/.project
@@ -24,6 +24,5 @@
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>com.ibm.etools.ctc.javaprojectnature</nature>
 	</natures>
 </projectDescription>

--- a/plugins/org.eclipse.jst.j2ee.webservice.ui/.project
+++ b/plugins/org.eclipse.jst.j2ee.webservice.ui/.project
@@ -24,6 +24,5 @@
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>com.ibm.etools.ctc.javaprojectnature</nature>
 	</natures>
 </projectDescription>

--- a/plugins/org.eclipse.jst.servlet.ui/.project
+++ b/plugins/org.eclipse.jst.servlet.ui/.project
@@ -24,6 +24,5 @@
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>com.ibm.etools.ctc.javaprojectnature</nature>
 	</natures>
 </projectDescription>

--- a/tests/org.eclipse.jst.j2ee.core.tests/commonArchiveResources/loose_module_workspace/LooseEAREjb/.project
+++ b/tests/org.eclipse.jst.j2ee.core.tests/commonArchiveResources/loose_module_workspace/LooseEAREjb/.project
@@ -6,35 +6,13 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
-			<name>com.ibm.wtp.migration.MigrationBuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
-		<buildCommand>
 			<name>org.eclipse.jdt.core.javabuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
-		<buildCommand>
-			<name>com.ibm.etools.validation.validationbuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
-		<buildCommand>
-			<name>com.ibm.wtp.j2ee.LibCopyBuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
-		<buildCommand>
-			<name>com.ibm.etools.j2ee.LibCopyBuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jem.workbench.JavaEMFNature</nature>
-		<nature>com.ibm.etools.j2ee.EJB2_0Nature</nature>
-		<nature>com.ibm.wtp.ejb.EJBNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.jem.beaninfo.BeanInfoNature</nature>
 	</natures>


### PR DESCRIPTION
Current versions of Eclipse attempt to look up missing natures in the Marketplace. This takes some time. If the lookup fails, you just get a normal Eclipse Marketplace window without any indication of failure (at least in 2023-12). So I think it's better to just remove the natures that seem to be unavailable now.

I removed the natures by editing the files by hand (rather than via "Project properties" -> "Project Natures").

I also got a popup for a JavaCC nature but lookup of that one succeeded and found a plugin.