### PR TITLE
Update Web project wizard to always add a Java library.

### DIFF
--- a/plugins/org.eclipse.jst.servlet.ui/servlet_ui/org/eclipse/jst/servlet/ui/project/facet/WebProjectFirstPage.java
+++ b/plugins/org.eclipse.jst.servlet.ui/servlet_ui/org/eclipse/jst/servlet/ui/project/facet/WebProjectFirstPage.java
@@ -54,9 +54,13 @@ public class WebProjectFirstPage extends J2EEComponentFacetCreationWizardPage {
 	    }
 	    else {
 		    facets.add( primaryFacetVersion );
-		    if (primaryFacetVersion == WebFacetUtils.WEB_40) 
+		    if( primaryFacetVersion == WebFacetUtils.WEB_60 )
 		    {
-		    	facets.add( JavaFacet.VERSION_1_8);
+		        facets.add( JavaFacet.VERSION_11 );
+		    }
+		    else if( primaryFacetVersion == WebFacetUtils.WEB_50 || primaryFacetVersion == WebFacetUtils.WEB_40 )
+		    {
+		        facets.add( JavaFacet.VERSION_1_8 );
 		    }
 		    else if( primaryFacetVersion == WebFacetUtils.WEB_31 )
 		    {
@@ -77,6 +81,11 @@ public class WebProjectFirstPage extends J2EEComponentFacetCreationWizardPage {
 		    else if( primaryFacetVersion == WebFacetUtils.WEB_23 || primaryFacetVersion == WebFacetUtils.WEB_22 )
 		    {
 		        facets.add( JavaFacet.VERSION_1_3 );
+		    }
+		    else
+		    {
+		        // Add a default version of Java in case a Web Facet is introduced but not in this list
+		        facets.add( JavaFacet.VERSION_11 );
 		    }
 	    }
 		return Collections.unmodifiableSet( facets );


### PR DESCRIPTION
Suggested fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=580990 - adding a Java library by default.

If there's a more standard correlation between Java version and Web facet version beyond 4.0 then I'm happy to update the PR to match.