### PR TITLE
JavaEE module disabled when the project has jst.webfragment facet con…

### DIFF
--- a/plugins/org.eclipse.jst.jee/plugin.xml
+++ b/plugins/org.eclipse.jst.jee/plugin.xml
@@ -327,11 +327,11 @@
 			<or>
 				<test property="org.eclipse.wst.common.project.facet.core.projectFacet" value="jst.appclient:10.0]" />
 				<test property="org.eclipse.wst.common.project.facet.core.projectFacet" value="jst.ejb:4.0]" />
-				<test property="org.eclipse.wst.common.project.facet.core.projectFacet" value="jst.utility]" />
+				<test property="org.eclipse.wst.common.project.facet.core.projectFacet" value="jst.utility" />
 				<test property="org.eclipse.wst.common.project.facet.core.projectFacet" value="jst.connector:2.1]" />
 				<test property="org.eclipse.wst.common.project.facet.core.projectFacet" value="jst.web" />
 				<test property="org.eclipse.wst.common.project.facet.core.projectFacet" value="jst.ear:[5.0-10.0]" />
-				<test property="org.eclipse.wst.common.project.facet.core.projectFacet" value="jst.webfragment]" />
+				<test property="org.eclipse.wst.common.project.facet.core.projectFacet" value="jst.webfragment" />
 			</or>
 		</enablement>        
       </moduleFactory>


### PR DESCRIPTION
Incorrect syntax in the webfragment facet property value in the moduleFactory configuration causes the ModuleFactory.isEnabled call to always return false with the webfragment projects. This error causes that dependencies with the configured webfragment facet to not be deployed within a web application. 

There is an open issue on this matter at [](https://github.com/eclipse-wtp-common/webtools.common/issues/13)